### PR TITLE
Add /root/.ssh directory to backup-config

### DIFF
--- a/root/etc/backup-config.d/nethserver-openssh.include
+++ b/root/etc/backup-config.d/nethserver-openssh.include
@@ -4,3 +4,4 @@
 /etc/ssh/ssh_host_rsa_key.pub
 /etc/ssh/ssh_host_dsa_key.pub
 /etc/ssh/ssh_host_key
+/root/.ssh


### PR DESCRIPTION
The directory /root/.ssh with ssh keys inside isn't added to backup files.
Add /root/.ssh directory to nethserver-openssh.include file used by backup-config.
NethServer/dev#5264