### PR TITLE
Make sure pam dependencies are satisfied

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -30,6 +30,7 @@ use esmith::Build::CreateLinks qw(:all);
 event_templates('nethserver-openssh-update', qw(
     /etc/ssh/sshd_config
     /etc/pam.d/sshd
+    /etc/nethserver/sshd.otp.force
 ));
 
 event_actions('nethserver-openssh-update', qw(

--- a/nethserver-openssh.spec
+++ b/nethserver-openssh.spec
@@ -9,6 +9,7 @@ URL: %{url_prefix}/%{name}
 BuildRequires: nethserver-devtools
 Requires: openssh-server
 Requires: nethserver-base
+Requires: pam_oath
 
 %description
 Configure and manage the sshd daemon


### PR DESCRIPTION
Install pam_oath.so otherwise users with password authentication will
not be able to login.

Also avoid cosmetic error on /var/log/secure:
`pam_listfile(sshd:auth): Couldn't open /etc/nethserver/sshd.otp.force`

NethServer/dev#6097