### PR TITLE
Require strong encryption if enabled

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/sshd/StrongEncryption
+++ b/root/etc/e-smith/db/configuration/defaults/sshd/StrongEncryption
@@ -1,0 +1,1 @@
+disabled

--- a/root/etc/e-smith/templates/etc/ssh/sshd_config/20Encryption
+++ b/root/etc/e-smith/templates/etc/ssh/sshd_config/20Encryption
@@ -1,0 +1,16 @@
+#
+# 20Encryption
+#
+{
+my $Encryption = $sshd{'StrongEncryption'} || 'disabled';
+
+  if ($Encryption eq 'enabled') {
+$OUT .=q(
+# Require strong Encryption
+Ciphers aes128-ctr,aes192-ctr,aes256-ctr
+HostKeyAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
+KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
+MACs hmac-sha2-256,hmac-sha2-512
+);
+  }
+}


### PR DESCRIPTION
The encryption of the ssh server might be enforced by the usage of strong cipher, this is the backend of this feature

https://github.com/NethServer/dev/issues/6218

the cipher list comes from https://www.ssh.com/ssh/sshd_config/ (sha1 has been removed)