### PR TITLE
config: use stronger ciphers

### DIFF
--- a/root/etc/e-smith/templates/etc/ssh/sshd_config/20Encryption
+++ b/root/etc/e-smith/templates/etc/ssh/sshd_config/20Encryption
@@ -7,10 +7,10 @@ my $Encryption = $sshd{'StrongEncryption'} || 'disabled';
   if ($Encryption eq 'enabled') {
 $OUT .=q(
 # Require strong Encryption
-Ciphers aes128-ctr,aes192-ctr,aes256-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
-MACs hmac-sha2-256,hmac-sha2-512
+Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
+HostKeyAlgorithms ssh-dss,ssh-ed25519,rsa-sha2-256,rsa-sha2-512
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
 );
   }
 }


### PR DESCRIPTION
Apply suggestions from ssh-audit tool.

The tool is available [here](https://github.com/jtesta/ssh-audit).
You can even use the online version: https://www.ssh-audit.com/

I've tested the access to the server with following clients:
- CentOS 7
- Fedora 31
- Putty

NethServer/dev#6218