### PR TITLE
Grant SSH access from local /etc/groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ the props of the service to configure openssh:
 
  sshd=service
     AllowGroups=group1,group2:sftp,group3
+    AllowLocalGroups=wheel,adm
     LoginGraceTime=2m
     MaxAuthTries=6
     PasswordAuthentication=yes
@@ -34,10 +35,10 @@ the props of the service to configure openssh:
     access=green,red
     status=enabled
 
-
-The prop ``AllowGroups`` is used by the service only if the property ``$sssd{'ShellOverrideStatus'}`` is enabled.
-
-- ``AllowGroups``: a comma separated list of group allowed to connect to the sshd service, if the option ``:sftp`` is specified then the group is restricted to SFTP
+- ``AllowGroups``: a comma separated list of groups from the accounts provider, allowed to connect with SSH.
+  If the option ``:sftp`` is specified then the group is restricted to SFTP.
+  This prop is considered if the property ``$sssd{'ShellOverrideStatus'}`` is enabled.
+- ``AllowLocalGroups``: a comma separated list of group names in ``/etc/groups`` that are granted full SSH and SFTP access.
 - ``SubsystemSftp``: (yes|no) enable the sftp service
 - ``LoginGraceTime``: The time after which the server disconnects if the user has not successfully logged in.
 - ``MaxAuthTries``: Specifies the maximum number of authentication attempts permitted per connection. 

--- a/root/etc/e-smith/templates/etc/ssh/sshd_config/45AllowGroups2Sshd
+++ b/root/etc/e-smith/templates/etc/ssh/sshd_config/45AllowGroups2Sshd
@@ -22,7 +22,7 @@
     my $PermitRootLogin = $sshd{'PermitRootLogin'} || "no";
     my $admin = $admins{'group'} || 'domain admins';
 
-    my @AllowGroups = ();
+    my @AllowGroups = $sshd{'AllowLocalGroups'} ? (split(',', $sshd{'AllowLocalGroups'})) : ();
     foreach ( $admin, split(',',$sshd{'AllowGroups'} || '')) {
         my ($group, $sftp) = split(':', $_);
 

--- a/root/etc/e-smith/templates/etc/ssh/sshd_config/70Restricted2Sftp
+++ b/root/etc/e-smith/templates/etc/ssh/sshd_config/70Restricted2Sftp
@@ -26,7 +26,7 @@
     }
 
     # We list non restricted group to SFTP
-    my $match_group_exp = join(",", 'root', @SftpUnRestricted);
+    my $match_group_exp = join(",", 'root', ($sshd{'AllowLocalGroups'} || ()), @SftpUnRestricted);
     $OUT .= qq(Match Group "$match_group_exp"\n);
     $OUT .= "    ForceCommand none\n";
     $OUT .= "    AllowTCPForwarding yes\n";


### PR DESCRIPTION
Add a new `AllowLocalGroups=` (empty) prop to grant SSH access to groups in the local /etc/groups file.

The current `AllowGroups` prop is designed to work with groups in the accounts provider DB and modified with the web UI.

This new prop slightly differs from `AllowGroups`. It is designed to grant access to additional users created by Anaconda at install time or with config management tools wherever an accounts provider is not wanted or still not configured.

- The default value is empty for backward compatibility
- We could plan to set it to `wheel` for NS 7.9. The `wheel` group is the default local administrative group of CentOS. Anaconda pushes the admin user created during the system installation in the wheel group.


https://github.com/NethServer/dev/issues/6279